### PR TITLE
override subject method of message

### DIFF
--- a/lib/mail-iso-2022-jp/message.rb
+++ b/lib/mail-iso-2022-jp/message.rb
@@ -35,5 +35,10 @@ module Mail
     end
     alias_method :text_part_without_iso_2022_jp_encoding=, :text_part=
     alias_method :text_part=, :text_part_with_iso_2022_jp_encoding=
+
+    def subject( val = nil )
+      _val = default :subject, val
+      Encodings.b_value_decode(_val)
+    end
   end
 end


### PR DESCRIPTION
hi
in [action_mailer preview](https://github.com/rails/rails/blob/v5.0.0.beta3/railties/lib/rails/templates/rails/mailers/email.html.erb#L86) , the subject is the encoded string, like this 
```ruby
=?ISO-2022-JP?B?GyRCRnxLXDhsGyhCIBskQjdvTD4bKEI=\?=\r\n"
```
read it is difficult. 
so, I override subject method for solve this problem.
