### PR TITLE
Support quoted display-name

### DIFF
--- a/lib/mail-iso-2022-jp/common_methods_for_field.rb
+++ b/lib/mail-iso-2022-jp/common_methods_for_field.rb
@@ -11,7 +11,7 @@ module Mail
 
     def b_value_encode(string)
       string.split(' ').map do |s|
-        if s =~ /\e/
+        if s =~ /\e/ || s == "\"" || start_with_specials?(s) || end_with_specials?(s)
           encode64(s)
         else
           s
@@ -41,6 +41,14 @@ module Mail
       value = value.to_s.gsub(/#{EM_DASH}/, HORIZONTAL_BAR)
       value = value.to_s.gsub(/#{DOUBLE_VERTICAL_LINE}/, PARALLEL_TO)
       value
+    end
+
+    def start_with_specials?(string)
+      string =~ /\A[\(\)<>\[\]:;@\\,\."]+[a-zA-Z]+\Z/
+    end
+
+    def end_with_specials?(string)
+      string =~ /\A[a-zA-Z]+[\(\)<>\[\]:;@\\,\."]+\Z/
     end
   end
 end

--- a/test/mail_test.rb
+++ b/test/mail_test.rb
@@ -58,6 +58,22 @@ class MailTest < ActiveSupport::TestCase
     assert_equal NKF::JIS, NKF.guess(mail.body.encoded)
   end
 
+  test "should send with ISO-2022-JP encoding and quoted display-name" do
+    mail = Mail.new(:charset => 'ISO-2022-JP') do
+      from '" <Yamada 太郎>" <taro@example.com>'
+      to '"<佐藤 Hanako> " <hanako@example.com>'
+      cc '" <X事務局> " <info@example.com>'
+      subject ''
+      body '日本語本文'
+    end
+    assert_equal 'ISO-2022-JP', mail.charset
+    assert_equal "From: =?ISO-2022-JP?B?Ig==?= =?ISO-2022-JP?B?PFlhbWFkYQ==?= =?ISO-2022-JP?B?GyRCQkBPOhsoQj4i?= <taro@example.com>\r\n", mail[:from].encoded
+    assert_equal "To: =?ISO-2022-JP?B?IjwbJEI6NEYjGyhC?= =?ISO-2022-JP?B?SGFuYWtvPg==?= =?ISO-2022-JP?B?Ig==?= <hanako@example.com>\r\n", mail[:to].encoded
+    assert_equal "Cc: =?ISO-2022-JP?B?Ig==?= =?ISO-2022-JP?B?PFgbJEI7dkwzNkkbKEI+?= =?ISO-2022-JP?B?Ig==?= <info@example.com>\r\n", mail[:cc].encoded
+    assert_equal "Subject: \r\n", mail[:subject].encoded
+    assert_equal NKF::JIS, NKF.guess(mail.body.encoded)
+  end
+
   test "should send with UTF-8 encoding" do
     mail = Mail.new do
       from '山田太郎 <taro@example.com>'


### PR DESCRIPTION
アドレスの表示名部分が、
メールの仕様上特別な意味を持つ記号を含むため、ダブルクォートで囲まれている場合に
iso-2022-jpでエンコードされないパターン(2パターン)がありましたのでパッチを作りました。

### 表示名の前後に半角スペースが入るパターン

##### アドレス
- `" ショップ" <aaa@example.com>`
- `"ショップ " <aaa@example.com>`

##### Before
```
=?UTF-8?Q?=22_=E3=82=B7=E3=83=A7=E3=83=83=E3=83=97=22_<aaa@example.?=\r
=?UTF-8?Q?com>?=\r
```
```
=?UTF-8?Q?=22=E3=82=B7=E3=83=A7=E3=83=83=E3=83=97_=22_<aaa@example.?=\r
=?UTF-8?Q?com>?=\r
```

##### After
```
=?ISO-2022-JP?B?Ig==?= =?ISO-2022-JP?B?GyRCJTclZyVDJVcbKEIi?= <aaa@example.com>
```
```
=?ISO-2022-JP?B?IhskQiU3JWclQyVXGyhC?= =?ISO-2022-JP?B?Ig==?= <aaa@example.com>\r
```

### "特別な意味を持つ記号 + 英数字" を含むパターン

- `"<佐藤 Hanako> " <hanako@example.com>`

##### Before
```
=?UTF-8?Q?=22<=E4=BD=90=E8=97=A4_Hanako>_=22_<hanako@example.com>?=\r
```

##### After

```
=?ISO-2022-JP?B?IjwbJEI6NEYjGyhC?= =?ISO-2022-JP?B?SGFuYWtvPg==?= =?ISO-2022-JP?B?Ig==?= <hanako@example.com>\r
```

ご確認のほどお願いいたします。

##### 参考にしたリンク

- [RFC5322(Internet Message Format)](http://srgia.com/docs/rfc5322j.html)
- [Action Mailerでfromフィールドに差出人名を表示したい - kotaroito's notes](http://kotaroito.hatenablog.com/entry/2016/09/23/103436)

> これにより、表示名（display-name）は quoted-string でない場合は specials を含めてはならないことを確認できました。裏を返せば、specials を使いたい場合は quoted-string とすればよいです。