### PR TITLE
iso-2022-jp should be handled as ISO-2022-JP in unstructured fields.

### DIFF
--- a/lib/mail-iso-2022-jp/field.rb
+++ b/lib/mail-iso-2022-jp/field.rb
@@ -5,7 +5,7 @@ require 'mail'
 module Mail
   class Field
     def initialize_with_iso_2022_jp_encoding(name, value = nil, charset = 'utf-8')
-      if charset == 'ISO-2022-JP' && value.kind_of?(String)
+      if charset.to_s.downcase == 'iso-2022-jp' && value.kind_of?(String)
         unless [ 'UTF-8', 'US-ASCII' ].include?(value.encoding.to_s)
           raise ::Mail::InvalidEncodingError.new(
             "The '#{name}' field is not encoded in UTF-8 nor in US-ASCII but in #{value.encoding}")

--- a/test/mail_test.rb
+++ b/test/mail_test.rb
@@ -364,4 +364,10 @@ class MailTest < ActiveSupport::TestCase
 
     assert_equal NKF::UTF8, NKF.guess(mail.text_part.body.encoded)
   end
+
+  test "should handle lowercase charset in unstructured fields" do
+    mail = Mail.new(:charset => 'iso-2022-jp')
+    mail["User-Agent"] = "test mailer"
+    assert_equal "User-Agent: test mailer\r\n", mail["User-Agent"].encoded
+  end
 end


### PR DESCRIPTION
Otherwise, Encoding::CompatibilityError is raised in the following program:

```ruby
require "mail-iso-2022-jp"

mail = Mail.new(charset: "iso-2022-jp")
mail["User-Agent"] = "test mailer"
p mail["User-Agent"].encoded #=> Encoding::CompatibilityError
```
