### PR TITLE
Add support for Ruby 3.4 frozen string literals

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ group :development, :test do
   gem 'net-imap', '~> 0.2.2'
   gem 'net-pop', '~> 0.1.1'
   gem 'net-smtp', '~> 0.3.0'
+  gem 'nkf', '~> 0.2.0'
   if rails_version == "edge"
     gem "actionmailer", :git => "git://github.com/rails/rails.git"
   elsif rails_version && rails_version.strip != ""

--- a/lib/mail-iso-2022-jp/header.rb
+++ b/lib/mail-iso-2022-jp/header.rb
@@ -3,7 +3,7 @@
 module Mail
   Header.class_eval do
     def encoded
-      buffer = ''
+      buffer = +''
       fields.each do |field|
         buffer << field.encoded rescue Encoding::CompatibilityError
       end

--- a/test/mail_test.rb
+++ b/test/mail_test.rb
@@ -58,6 +58,13 @@ class MailTest < ActiveSupport::TestCase
     assert_equal NKF::JIS, NKF.guess(mail.body.encoded)
   end
 
+  test "should encode header" do
+    mail = Mail.new(:charset => 'ISO-2022-JP') do
+      header "Subject: hello world\r\n"
+    end
+    assert_equal "Subject: hello world\r\n", mail.header.encoded
+  end
+
   test "should send with ISO-2022-JP encoding and quoted display-name" do
     mail = Mail.new(:charset => 'ISO-2022-JP') do
       from '" <Yamada 太郎>" <taro@example.com>'


### PR DESCRIPTION
With Ruby 3.4 the `Mail::Header` patch starts to issue warnings
```
header.rb:9: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
```

The fix uses `Enumerable#each_with_object` to gracefully ignore any raises encoding errors followed by a `#join`.